### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Ever seen thove __long__ tracebacks? Welp, this is for you!
 There are requirements:
 # REQUIREMENTS
 - __Colorama__ colorcodes the line with the error.
-- __Tkinter__ for the file dialouge, probably installed but best to check.
+- __Tkinter__ for the file dialogue, probably installed but best to check.
 # MAIN WEBSITE
 Go to the website at https://wiktorlaskowski.github.io/Minitrace-Python-Library/
 # SETUP


### PR DESCRIPTION
## Summary
- fix a typo in the requirements list

## Testing
- `python -m py_compile minitrace.py`
- `python -m py_compile minitracelegacy1.py`


------
https://chatgpt.com/codex/tasks/task_e_68477365fdc483258fa66958c489e1ee