### PR TITLE
Fix README typo and improve plain traceback

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 # Minitrace Python Library
 Shorten those verbose Python tracebacks to something more compact, comes with saving!
 
-Ever seen thove __long__ tracebacks? Welp, this is for you!
-There are requirements:
+Ever seen those __long__ tracebacks? Welp, this is for you!
 # REQUIREMENTS
 - __Colorama__ colorcodes the line with the error.
 - __Tkinter__ for the file dialogue, probably installed but best to check.

--- a/minitrace.py
+++ b/minitrace.py
@@ -39,7 +39,10 @@ class MiniTrace:
             for line in reversed(trace_lines)
         ]
         expectation = f"{exc_type.__name__}: {exc_value}"
-        return f"Traceback: Most recent calls\n" + "\n".join(formatted_lines)
+        formatted_lines.append(expectation)
+        return (
+            "Traceback: Most recent calls\n" + "\n".join(formatted_lines)
+        )
 
     @classmethod
     def init(cls):
@@ -62,7 +65,11 @@ class MiniTrace:
         Tk().withdraw()
         file_path = filedialog.asksaveasfilename(
             defaultextension=".log",
-            filetypes=[("Log files", "*.log"), ("Text files", "*.txt"), ("No extension iles", ".")]
+            filetypes=[
+                ("Log files", "*.log"),
+                ("Text files", "*.txt"),
+                ("All files", "*.*"),
+            ]
         )
         if file_path:
             with open(file_path, "w") as file:


### PR DESCRIPTION
## Summary
- fix typos in README header section
- include error message in plain traceback output
- show "All files" filter in save dialog

## Testing
- `python -m py_compile minitrace.py minitracelegacy1.py`

------
https://chatgpt.com/codex/tasks/task_e_68477483c0d883259807e8988ce82562